### PR TITLE
Refactored get_emddims out of get_emdgroup.

### DIFF
--- a/ncempy/io/emd.py
+++ b/ncempy/io/emd.py
@@ -182,6 +182,36 @@ class fileEMD:
         
         return emds
 
+    def get_emddims(self, group):
+        '''Get the emdtype dimensions saved in in group.
+        
+        Parameters:
+            group (h5py._hl.group.Group):   Reference to the emdtype HDF5 group.
+        
+        Returns:
+            (tuple):    List of dimension vectors plus labels and units.
+                
+        '''
+        # get the dims
+        dims = []
+        for i in range(len(group['data'].shape)):
+            dim = group['dim{}'.format(i+1)]
+            # save them as (vector, name, units)
+            
+            if isinstance(dim.attrs['name'], np.ndarray):
+                name = dim.attrs['name'][0]
+            else:
+                name = dim.attrs['name']
+            
+            if isinstance(dim.attrs['units'], np.ndarray):
+                units = dim.attrs['units'][0]
+            else:
+                units = dim.attrs['units']
+                
+            dims.append( (dim[:], name.decode('utf-8'), units.decode('utf-8')) )
+        
+        dims = tuple(dims)
+        return(dims)
 
     def get_emdgroup(self, group):
         '''Get the emdtype data saved in in group.
@@ -212,26 +242,9 @@ class fileEMD:
             # get the data
             data = group['data'][:]
             
-            # get the dims
-            dims = []
-            for i in range(len(data.shape)):
-                dim = group['dim{}'.format(i+1)]
-                # save them as (vector, name, units)
-                
-                if isinstance(dim.attrs['name'], np.ndarray):
-                    name = dim.attrs['name'][0]
-                else:
-                    name = dim.attrs['name']
-                
-                if isinstance(dim.attrs['units'], np.ndarray):
-                    units = dim.attrs['units'][0]
-                else:
-                    units = dim.attrs['units']
-                    
-                dims.append( (dim[:], name.decode('utf-8'), units.decode('utf-8')) )
-            
-            dims = tuple(dims)
-            
+            # get the dimensions.
+            dims = self.get_emddims(group)
+
             return data, dims
             
         except:
@@ -239,8 +252,7 @@ class fileEMD:
             print('Content of "{}" does not seem to be in emd specified shape'.format(group.name))
             
             return None
-            
-
+ 
     def write_dim(self, label, dim, parent):
         '''Auxiliary function to write a dim dataset to parent.
         


### PR DESCRIPTION
Allows someone to get dimensions for a group without also getting the data.  This is useful for when the data is large and it would be inefficient to pull it all into RAM as a numpy array.