### PR TITLE
Edstomo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include ncempy/edstomo/Elam
+include ncempy/edstomo/Elam/ElamDB12.txt

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ The newest version can be installed using pip:
 
 ``>> pip install ncempy``
 
+To ensure dependencies for the EDS tomography reconstruction are installed:
+
+``>> pip install ncempy[edstomo]``
+
 Components
 ==========
 

--- a/ncempy/README.rst
+++ b/ncempy/README.rst
@@ -61,7 +61,7 @@ We recommend installing the ``ncempy`` package from PyPi:
 
 If you wish to install the optional EDSTomo module then run:
 
-``pip install 'git+https://github.com/ercius/openNCEM.git@development#egg=ncempy[edstomo]'``
+``pip install 'ncempy[edstomo]'``
 
 License
 -------

--- a/ncempy/edstomo/README.rst
+++ b/ncempy/edstomo/README.rst
@@ -1,0 +1,23 @@
+ncempy.edstomo
+==========
+
+The ``ncempy.edstomo`` module supports STEM/EDS tomographic reconstruction.  The code works as part of a larger workflow that can be seen in the examples in ncempy.data.  Please visit https://github.com/ercius/openNCEM/tree/master/ncempy/data/L2083-K-4-1 for a good start.
+
+Contents
+--------
+
+Overview of contents with short description:
+
++---------------------------+--------------------------------------------------------------------+
+| Module                    | Description                                                        |
++===========================+====================================================================+
+| CharactersiticEmission    | X-ray fluorescence energies.                                       |
++---------------------------+--------------------------------------------------------------------+
+| DoGenfire                 | Wrapper to run GENFIRE tomographic reconstructions.                |
++---------------------------+--------------------------------------------------------------------+
+| Bruker                    | Move datasets from Bruker bcf files into emd files.                |
++---------------------------+--------------------------------------------------------------------+
+| preprocess                | Tomography helper functions used before reconstruction.            |
++---------------------------+--------------------------------------------------------------------+
+| postprocess               | Tomography helper functions used after reconstruction.             |
++---------------------------+--------------------------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'ncempy/long_description.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+
+
 setup(
     name='ncempy',
 
@@ -63,7 +65,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'test', 'data']),
+    packages=find_packages(exclude=['contrib', 'docs', 'test']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:
@@ -86,15 +88,16 @@ setup(
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
-    #package_data={
-    #    'sample': ['package_data.dat'],
-    #},
+    # package_data={
+    #     'edstomo': ['Elam/ElamDB12.txt'],
+    # },
+    include_package_data=True,
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[('ncempy', ['edstomo/Elam/ElamDB12.txt'])],
+    # data_files=[('ncempy', ['ncempy/edstomo/Elam/ElamDB12.txt'])],
     
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ setup(
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    #data_files=[('my_data', ['data/data_file'])],
+    data_files=[('ncempy', ['edstomo/Elam/ElamDB12.txt'])],
+    
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.


### PR DESCRIPTION
Changed setup.py so the edstomo directory is always installed when you pip install.  You still have to pip install 'ncempy[edstomo]' if you want to install the dependencies like hyperspy.  Also, the data directory with the sample tomographic datasets is never installed by pip -- I don't think it ever should be since people don't go into their virtualenv innards to find sample code.  Instead they will just have to download that from github.

I added/modified readme files to better reflect edstomo.

We need to do a readthedocs rebuild since it doesn't include edstomo.