### PR TITLE
I/O Plugin for Nion Swift

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ The openNCEM collection comes with different components, described below.
 
 
 **nionswift_plugin**
-    A plugin for `Nion Swift<http://nion.com/swift>`_ that adds openNCEM's ``ser``, ``emd``, and Velox file import capabilities (for images only, spectrum images are not currently supported). 
+    A plugin for Nion Swift (http://nion.com/swift) that adds openNCEM's ``ser``, ``emd``, and Velox file import capabilities (for images only, spectrum images are not currently supported). 
 
 Commands
 ========

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ The openNCEM collection comes with different components, described below.
 
 
 **nionswift_plugin**
-    A plugin for [Nion Swift](http://nion.com/swift) that adds openNCEM's ``ser``, ``emd``, and Velox file import capabilities (for images only, spectrum images are not currently supported). 
+    A plugin for `Nion Swift<http://nion.com/swift>`_ that adds openNCEM's ``ser``, ``emd``, and Velox file import capabilities (for images only, spectrum images are not currently supported). 
 
 Commands
 ========

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ The openNCEM collection comes with different components, described below.
 **tools**
     The tools build leveraging the algorithms and routines provided in the libraries/packages. They are subordered by the different problems they address.
 
+
+**nionswift_plugin**
+    A plugin for [Nion Swift](http://nion.com/swift) that adds openNCEM's ``ser``, ``emd``, and Velox file import capabilities (for images only, spectrum images are not currently supported). 
+
 Commands
 ========
 

--- a/ncempy/io/emd.py
+++ b/ncempy/io/emd.py
@@ -136,12 +136,13 @@ class fileEMD:
             
 
     def __del__(self):
+        pass
         '''Destructor for EMD file object. 
         
         '''
         # close the file
         #if(not self.file_hdl.closed):
-        self.file_hdl.close()
+        #self.file_hdl.close()
 
     def __enter__(self):
         '''Implement python's with staement

--- a/nionswift_plugin/ncempy_io/__init__.py
+++ b/nionswift_plugin/ncempy_io/__init__.py
@@ -8,10 +8,9 @@ import pathlib
 import logging
 
 # third party libraries
-from nion.data import DataAndMetadata
 
 # local libraries
-
+from .ncem_image_utils import loadSER, loadEMD, loadMRC
 
 _ = gettext.gettext
 
@@ -22,12 +21,21 @@ class OpenNCEMDelegate(object):
 		self.__api = api
 		self.io_handler_id = "openNCEM-io-handler"
 		self.io_handler_name = _("openNCEM Supported")
-		self.io_handler_extensions = ["emd", "ser", "emi", "mrc"]
+		self.io_handler_extensions = ["emd", "ser", "mrc", "h5"]
 
 
 
 	def read_data_and_metadata(self, extension, file_path):
 		logging.debug('entered read data_and_metadata')
+		assert extension in ['ser','emd','mrc','h5'], 'Unsupported extension'
+
+		if extension == 'ser':
+			return loadSER(file_path)
+		if extension in ['h5','emd']:
+			return loadEMD(file_path)
+		if extension == 'mrc':
+			return loadMRC(file_path)
+
 
 	def can_write_data_and_metadata(self, data_and_metadata, extension):
 		logging.debug('entered can_write_data_and_metadata')

--- a/nionswift_plugin/ncempy_io/__init__.py
+++ b/nionswift_plugin/ncempy_io/__init__.py
@@ -1,5 +1,6 @@
 """
-	Support for openNCEM file formats: *.emd, *.ser/*.emi, *.mrc
+	Support for images in openNCEM  supported 
+	file formats: *.emd and *.ser
 """
 
 # standard libraries
@@ -10,7 +11,7 @@ import logging
 # third party libraries
 
 # local libraries
-from .ncem_image_utils import loadSER, loadEMD, loadMRC
+from .ncem_image_utils import loadSER, loadEMD
 
 _ = gettext.gettext
 
@@ -21,20 +22,20 @@ class OpenNCEMDelegate(object):
 		self.__api = api
 		self.io_handler_id = "openNCEM-io-handler"
 		self.io_handler_name = _("openNCEM Supported")
-		self.io_handler_extensions = ["emd", "ser", "mrc", "h5"]
+		self.io_handler_extensions = ["emd", "ser", "h5"]
 
 
 
 	def read_data_and_metadata(self, extension, file_path):
 		logging.debug('entered read data_and_metadata')
-		assert extension in ['ser','emd','mrc','h5'], 'Unsupported extension'
+		assert extension in ['ser','emd','h5'], 'Unsupported extension'
 
 		if extension == 'ser':
 			return loadSER(file_path)
 		if extension in ['h5','emd']:
 			return loadEMD(file_path)
-		if extension == 'mrc':
-			return loadMRC(file_path)
+		# if extension == 'mrc':
+		# 	return loadMRC(file_path)
 
 
 	def can_write_data_and_metadata(self, data_and_metadata, extension):

--- a/nionswift_plugin/ncempy_io/__init__.py
+++ b/nionswift_plugin/ncempy_io/__init__.py
@@ -1,0 +1,60 @@
+"""
+	Support for openNCEM file formats: *.emd, *.ser/*.emi, *.mrc
+"""
+
+# standard libraries
+import gettext
+import pathlib
+import logging
+
+# third party libraries
+from nion.data import DataAndMetadata
+
+# local libraries
+
+
+_ = gettext.gettext
+
+
+class OpenNCEMDelegate(object):
+
+	def __init__(self,api):
+		self.__api = api
+		self.io_handler_id = "openNCEM-io-handler"
+		self.io_handler_name = _("openNCEM Supported")
+		self.io_handler_extensions = ["emd", "ser", "emi", "mrc"]
+
+
+
+	def read_data_and_metadata(self, extension, file_path):
+		logging.debug('entered read data_and_metadata')
+
+	def can_write_data_and_metadata(self, data_and_metadata, extension):
+		logging.debug('entered can_write_data_and_metadata')
+		return None
+
+	def write_data_and_metadata(self, data_and_metadata, file_path_str: str, extension):
+		logging.debug('entered write_data_and_metadata')
+
+
+
+
+
+class OpenNCEMExtension(object):
+
+	# required for Swift to recognize this as an extension class.
+	extension_id = "openNCEM.swift.extensions.filetypes"
+
+	def __init__(self, api_broker):
+		logging.debug('started an openNCEM extension...')
+		# grab the api object.
+		api = api_broker.get_api(version="1", ui_version="1")
+		# be sure to keep a reference or it will be closed immediately.
+		self.__io_handler_ref = api.create_data_and_metadata_io_handler(OpenNCEMDelegate(api))
+
+
+	def close(self):
+		# close will be called when the extension is unloaded. in turn, close any references so they get closed. this
+		# is not strictly necessary since the references will be deleted naturally when this object is deleted.
+		self.__io_handler_ref.close()
+		self.__io_handler_ref = None

--- a/nionswift_plugin/ncempy_io/__init__.py
+++ b/nionswift_plugin/ncempy_io/__init__.py
@@ -54,7 +54,7 @@ class OpenNCEMExtension(object):
 	extension_id = "openNCEM.swift.extensions.filetypes"
 
 	def __init__(self, api_broker):
-		logging.debug('started an openNCEM extension...')
+		#logging.debug('started an openNCEM extension...')
 		# grab the api object.
 		api = api_broker.get_api(version="1", ui_version="1")
 		# be sure to keep a reference or it will be closed immediately.

--- a/nionswift_plugin/ncempy_io/ncem_image_utils.py
+++ b/nionswift_plugin/ncempy_io/ncem_image_utils.py
@@ -77,5 +77,36 @@ def loadEMD(fpath):
 
 		dimensional_calibrations = [Calibration(origin[i],pixsize[i],units[i]) for i in range(len(origin))]
 
-		return DataAndMetadata.new_data_and_metadata(data,dimensional_calibrations=dimensional_calibrations,data_descriptor=descriptor)		
+		return DataAndMetadata.new_data_and_metadata(data,dimensional_calibrations=dimensional_calibrations,data_descriptor=descriptor)
+	else:
+		# The file is a Velox EMD. Read using the Velox reader
+		# Currently supports only images
+		emd = fileEMDVelox(fpath)
+
+		first_dset, first_meta = emd.get_dataset(emd.list_data[0])
+
+		data = np.zeros((len(emd.list_data),first_dset.shape[0],first_dset.shape[1]),
+			dtype=first_dset.dtype)
+
+		dimensional_calibrations = [Calibration(0., first_meta['pixelSize'][0], first_meta['pixelSizeUnit'][0]),
+			Calibration(0., first_meta['pixelSize'][0], first_meta['pixelSizeUnit'][0])]
+
+		if len(emd.list_data) == 1:
+			descriptor = DataAndMetadata.DataDescriptor(False,0,2)
+		else:
+			descriptor = DataAndMetadata.DataDescriptor(False,1,2)
+			dimensional_calibrations.append(Calibration(0,0,''))
+
+
+		for i in range(len(emd.list_data)):
+			dset, meta = emd.get_dataset(emd.list_data[i])
+
+			data[i,:,:] = dset
+
+		return DataAndMetadata.new_data_and_metadata(np.squeeze(data),dimensional_calibrations=dimensional_calibrations,data_descriptor=descriptor)
+
+
+
+
+
 

--- a/nionswift_plugin/ncempy_io/ncem_image_utils.py
+++ b/nionswift_plugin/ncempy_io/ncem_image_utils.py
@@ -83,20 +83,20 @@ def loadEMD(fpath):
 		# Currently supports only images
 		emd = fileEMDVelox(fpath)
 
+		if len(emd.list_data) == 1:
+			descriptor = DataAndMetadata.DataDescriptor(False,0,2)
+			dimensional_calibrations = []
+		else:
+			descriptor = DataAndMetadata.DataDescriptor(True,0,2)
+			dimensional_calibrations = [Calibration(0,0,'')]
+
 		first_dset, first_meta = emd.get_dataset(emd.list_data[0])
 
 		data = np.zeros((len(emd.list_data),first_dset.shape[0],first_dset.shape[1]),
 			dtype=first_dset.dtype)
 
-		dimensional_calibrations = [Calibration(0., first_meta['pixelSize'][0], first_meta['pixelSizeUnit'][0]),
-			Calibration(0., first_meta['pixelSize'][0], first_meta['pixelSizeUnit'][0])]
-
-		if len(emd.list_data) == 1:
-			descriptor = DataAndMetadata.DataDescriptor(False,0,2)
-		else:
-			descriptor = DataAndMetadata.DataDescriptor(False,1,2)
-			dimensional_calibrations.append(Calibration(0,0,''))
-
+		dimensional_calibrations.append(Calibration(0., first_meta['pixelSize'][0], first_meta['pixelSizeUnit'][0]))
+		dimensional_calibrations.append(Calibration(0., first_meta['pixelSize'][1], first_meta['pixelSizeUnit'][1]))
 
 		for i in range(len(emd.list_data)):
 			dset, meta = emd.get_dataset(emd.list_data[i])

--- a/nionswift_plugin/ncempy_io/ncem_image_utils.py
+++ b/nionswift_plugin/ncempy_io/ncem_image_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import logging
 
 from ncempy.io.ser import serReader
-from ncempy.io.mrc import mrcReader
+#from ncempy.io.mrc import mrcReader
 from ncempy.io.emd import fileEMD
 from ncempy.io.emdVelox import fileEMDVelox
 
@@ -31,9 +31,6 @@ def loadSER(fpath):
 
 def loadMRC(fpath):
 	pass
-
-
-
 
 
 def loadEMD(fpath):

--- a/nionswift_plugin/ncempy_io/ncem_image_utils.py
+++ b/nionswift_plugin/ncempy_io/ncem_image_utils.py
@@ -1,0 +1,37 @@
+import numpy as np
+import logging
+
+from ncempy.io.ser import serReader
+
+from nion.data.Calibration import Calibration
+from nion.data import DataAndMetadata
+
+
+def loadSER(fpath):
+	logging.debug('Reading ser file with openNCEM')
+
+	ser = serReader(fpath)
+
+	data = ser['data']
+
+	dimensional_calibrations = [Calibration(ser['pixelOrigin'][i],ser['pixelSize'][i],ser['pixelUnit'][i]) for i in range(len(ser['pixelSize']))]
+	
+	# currently only supporting 2D images and 3D sequences
+	if len(data.shape) == 2:
+		descriptor = DataAndMetadata.DataDescriptor(False,0,2)
+	if len(data.shape) == 3:
+		descriptor = DataAndMetadata.DataDescriptor(False,1,2)
+	else:
+		descriptor = DataAndMetadata.DataDescriptor(False,0,len(data.shape))
+
+	return DataAndMetadata.new_data_and_metadata(data,dimensional_calibrations=dimensional_calibrations,data_descriptor=descriptor)
+
+def loadMRC(fpath):
+	pass
+
+
+
+
+
+def loadEMD(fpath):
+	pass

--- a/nionswift_plugin/ncempy_io/ncem_image_utils.py
+++ b/nionswift_plugin/ncempy_io/ncem_image_utils.py
@@ -2,6 +2,9 @@ import numpy as np
 import logging
 
 from ncempy.io.ser import serReader
+from ncempy.io.mrc import mrcReader
+from ncempy.io.emd import fileEMD
+from ncempy.io.emdVelox import fileEMDVelox
 
 from nion.data.Calibration import Calibration
 from nion.data import DataAndMetadata
@@ -34,4 +37,45 @@ def loadMRC(fpath):
 
 
 def loadEMD(fpath):
-	pass
+	# first try to open as a properly formatted EMD file (Berkeley specification)
+	emd = fileEMD(fpath,readonly=True)
+
+	# check if there are any valid EMD datasets:
+	if len(emd.list_emds) > 0:
+		# the file is a Berkeley EMD. Currently supporting only first dataset
+		data = np.array(emd.list_emds[0]['data'])
+
+		if len(data.shape) == 2:
+			descriptor = DataAndMetadata.DataDescriptor(False,0,2)
+		if len(data.shape) == 3:
+			descriptor = DataAndMetadata.DataDescriptor(False,1,2)
+		if len(data.shape) == 4:
+			descriptor = DataAndMetadata.DataDescriptor(False,2,2)
+		if len(data.shape) == 5:
+			descriptor = DataAndMetadata.DataDescriptor(True,2,2)
+			data = np.moveaxis(data,4,0)
+			data = np.swapaxes(data,1,3)
+			data = np.swapaxes(data,2,4)
+		else:
+			descriptor = DataAndMetadata.DataDescriptor(False,0,len(data.shape))
+
+		origin = []
+		pixsize = []
+		units = []
+		for j in range(len(data.shape)):
+			dim = emd.list_emds[0]['dim'+str(j+1)]
+			if isinstance(dim[0],bytes):
+				# this axis is a complex datatype, so use 0 as the origin, 1 as the step, and imag as units
+				origin.append(0)
+				pixsize.append(1)
+				units.append('imag')
+			else:
+				origin.append(dim[0])
+				pixsize.append( dim[1]-dim[0])
+				units.append('pixels')
+
+
+		dimensional_calibrations = [Calibration(origin[i],pixsize[i],units[i]) for i in range(len(origin))]
+
+		return DataAndMetadata.new_data_and_metadata(data,dimensional_calibrations=dimensional_calibrations,data_descriptor=descriptor)		
+


### PR DESCRIPTION
This adds an I/O delegate to the `nionswift_plugin` namespace that uses `ncempy` to handle opening `*.emd` (Berkeley and Velox) and `*.ser` files in the Nion Swift *Import Data...* dialog. Only image data is currently supported. 

No extra install steps are needed, just `pip install ncempy` as usual and Swift will find it.

I've tested this with many TIA and Velox files I have, though I'm sure there are cases I haven't tested so if something doesn't work right just point me to the file and I'll try to make it work!