### PR TITLE
Add ncempy/*rst and LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include ncempy/edstomo/Elam
 include ncempy/edstomo/Elam/ElamDB12.txt
+include ncempy/*.rst
+include LICENSE


### PR DESCRIPTION
Currently it is impossible to use the PyPI source tarball to install ncempy,
due to the missing ncempy/long_description.rst file.