### PR TITLE
Remove h5py_cache dependency

### DIFF
--- a/ncempy/README.rst
+++ b/ncempy/README.rst
@@ -41,7 +41,6 @@ It relies on the following packages:
 * scipy
 * matplotlib (for plotting)
 * h5py (for EMD files)
-* h5py_cache (for EMD Velox files)
 
 edstomo has addtional optional packages:
 * glob2

--- a/ncempy/io/emdVelox.py
+++ b/ncempy/io/emdVelox.py
@@ -12,10 +12,8 @@ import json
 import numpy as np
 import h5py
 
-import h5py_cache
-
 class fileEMDVelox:
-    ''' Class to represent Velox EMD files. It uses the h5py_cache module
+    ''' Class to represent Velox EMD files. It uses the h5py caching functionality
     to increase the default cache size from 1MB to 10MB. This significantly
     improves file reading for EMDVelox files which are written with Fortran-
     style ordering and an inefficient choice of chunking.
@@ -70,8 +68,7 @@ class fileEMDVelox:
 
         # try opening the file
         try:
-            #self.file_hdl = h5py.File(filename, 'r')
-            self.file_hdl = h5py_cache.File(filename, 'r', chunk_cache_mem_size=10*1024**2)
+            self.file_hdl = h5py.File(filename, 'r', rdcc_nbytes=10*1024**2)
         except:
             print('Error opening file for readonly: "{}"'.format(filename))
             raise

--- a/ncempy/requirements.txt
+++ b/ncempy/requirements.txt
@@ -2,7 +2,6 @@ h5py
 numpy
 scipy
 h5py
-h5py_cache
 matplotlib
 glob2[edstomo]
 scipy[edstomo]

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy', 'scipy', 'matplotlib', 'h5py', 'h5py_cache'],       
+    install_requires=['numpy', 'scipy', 'matplotlib', 'h5py>=2.9.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Functionality has been merged into h5py since 2.9.0, released almost
one year ago.