### PR TITLE
add dm4 and new path in writeTags method

### DIFF
--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -804,12 +804,19 @@ class fileDM:
         else:
             pass
 
-    def writeTags(self):
+    def writeTags(self, new_folder_path_for_tags=None):
         """Write  out all tags as human readable text to a text file
         in the same directory and with a the same name as the DM file.
 
         """
-        fnameOutPrefix = self.filename.split('.dm3')[0]
+        if('.dm3' in self.filename): # in case different file formats are used and for generality
+            fnameOutPrefix = self.filename.split('.dm3')[0]
+        elif('.dm4' in self.filename):
+            fnameOutPrefix = self.filename.split('.dm4')[0]
+        
+        if(new_path_for_tags): # to allow someone to write the tags in a different place than the dm file
+            fnameOutPrefix = new_folder_path_for_tags + '/' + self.filename.split('/')[-1]
+        
         try:
             # open a text file to write out the tags
             with open(fnameOutPrefix + '_tags.txt', 'w') as fidOut:


### PR DESCRIPTION
Hi, i was using your great library to read dm4 files and i love the writeTags method, except i use dm4s not dm3 and i thought it might be a functionality more people would like. I used to just copy your source code and modify it a bit for my scripts. I hope you find it useful enough to write it in your package. I also added a bit about being able to save the tags file in a different location in case it's useful for some people.
