### PR TITLE
Remove dangling references with on_memory=True

### DIFF
--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -21,6 +21,7 @@ On Memory mode:
 
 from pathlib import Path
 import mmap
+import copy
 import os
 from os import stat as filestats
 from os.path import basename as os_basename
@@ -353,8 +354,8 @@ class fileDM:
         aa = self.fromfile(self.fid, dtype=np.dtype([('fileSize', self._specialType),
                                                      ('endianType', '>u4')]), count=1)
 
-        self.fileSize = aa['fileSize']
-        self._endianType = aa['endianType']
+        self.fileSize = copy.deepcopy(aa['fileSize'])
+        self._endianType = copy.deepcopy(aa['endianType'])
 
         if self._endianType != 1:
             # print('File is not written Little Endian (PC) format and can not be read by this program.')


### PR DESCRIPTION
Fixes #39

This works for the easy reproducer from #39 - it's possible that other fields need similar treatment.

As an alternative, these fields could also be cleared in `__del__` prior to closing the `mmap` object.