### PR TITLE
Add Metadata function

### DIFF
--- a/ncempy/algo/peak_find.py
+++ b/ncempy/algo/peak_find.py
@@ -100,7 +100,7 @@ def peakFind2D(image, threshold):
              (image > threshold * np.max(image))
 
     positions = np.array(np.where(pLarge * image)).T.copy()  # return array as [num,posXY]
-    return positions.astype(np.int)
+    return positions.astype(int)
 
 
 def peakFind3D(vol, threshold):

--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -391,6 +391,10 @@ class fileDM:
         information about hte experimental parameters. This is a (useful) subset of the information contains in the
         allTags attribute.
 
+        Note: some DM files contain extra information called the Tecnai Microscope Info. This is added to the metadata
+        dictionary as a string.
+
+
         Parameters
         ----------
         index : int
@@ -422,18 +426,18 @@ class fileDM:
                     new_key = ' '.join(kk_split[4:])
                     self.metadata[new_key] = ii
 
-            # if 'Tecnai.Microscope Info.arrayOffset' in kk:
-            #     try:
-            #         offset = self.allTags[prefix1 + 'Tecnai.Microscope Info.arrayOffset']
-            #         size = self.allTags[prefix1 + 'Tecnai.Microscope Info.arraySize']
-            #         dtype = self.allTags[prefix1 + 'Tecnai.Microscope Info.arrayType']
-            #         cur_offset = self.fid.tell()
-            #         self.seek(self.fid, offset)
-            #         stringData = self.fromfile(self.fid, count=size, dtype=np.uint8)
-            #         tecnai = self._bin2str(stringData)
-            #         print(tecnai)
-            #     except KeyError:
-            #         print('key error')
+            if 'Tecnai.Microscope Info.arrayOffset' in kk:
+                try:
+                    offset = self.allTags[prefix1 + 'Tecnai.Microscope Info.arrayOffset']
+                    size = self.allTags[prefix1 + 'Tecnai.Microscope Info.arraySize']
+                    dtype = self.allTags[prefix1 + 'Tecnai.Microscope Info.arrayType']
+                    cur_offset = self.fid.tell()
+                    self.seek(self.fid, offset)
+                    string_data = self.fromfile(self.fid, count=size, dtype=np.uint16)
+                    tecnai = ''.join([chr(ii) for ii in string_data]).replace('\u2028', ';')  # replace new line with ;
+                    self.metadata['Tecnai Microscope Info'] = tecnai
+                except KeyError:
+                    print('Tecnai parse error')
 
         return self.metadata
 

--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -1030,7 +1030,7 @@ class fileDM:
                 outputDict['pixelSize'] = self.scale[jj:jj + self.dataShape[ii]][::-1]
                 outputDict['pixelOrigin'] = self.origin[jj:jj + self.dataShape[ii]][::-1]
 
-            # Add calibrated intensity
+            # Add calibrated intensity (this should be in getMetadata
             #prefix1 = '.ImageList.{}.ImageData.Calibrations.Brightness.'.format(ii)
             #outputDict['intensityScale'] = self.brightnessScale
             #outputDict['intensityUnits'] = self.brightnessUnit

--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -1196,7 +1196,8 @@ def dmReader(filename, dSetNum=0, verbose=False, on_memory=True):
     with fileDM(filename, verbose, on_memory=on_memory) as f1:
         # Get the requested dataset
         im1 = f1.getDataset(dSetNum)
-
+        allTags = f1.allTags
+        
     # Now prepare nice coordinates (like energy loss axis for spectra)
     coords = []
     for pixel_size, pixel_origin, pixel_unit, sh in zip(im1['pixelSize'], im1['pixelOrigin'], im1['pixelUnit'],
@@ -1210,13 +1211,10 @@ def dmReader(filename, dSetNum=0, verbose=False, on_memory=True):
     im1['coords'] = coords
     
     # Add calibrated intensity
-    prefix1 = 'ImageList.{}.ImageData.Calibrations.Brightness.'.format(dsetNum+1)
-    for kk,vv in self.allTags.items():
-        pos1 = kk.find(prefix1)
-        if pos1 > -1:
-            if kk.split(',')[-1] is 'Origin':
-                print('origin)
-        
+    prefix1 = '.ImageList.{}.ImageData.Calibrations.Brightness.'.format(dSetNum+1)
+    im1['intensityScale'] = allTags[prefix1 + 'Scale']
+    im1['intensityUnits'] = allTags[prefix1 + 'Units']
+    im1['intensityOrigin'] = allTags[prefix1 + 'Origin']
     
     # Remove confusing pixelOrigin. Use coords instead
     del im1['pixelOrigin']

--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -1208,7 +1208,16 @@ def dmReader(filename, dSetNum=0, verbose=False, on_memory=True):
             eLoss = np.round(np.linspace(0, pixel_size * (sh - 1), sh) + pixel_origin, decimals=4)
             coords.append(eLoss)
     im1['coords'] = coords
-
+    
+    # Add calibrated intensity
+    prefix1 = 'ImageList.{}.ImageData.Calibrations.Brightness.'.format(dsetNum+1)
+    for kk,vv in self.allTags.items():
+        pos1 = kk.find(prefix1)
+        if pos1 > -1:
+            if kk.split(',')[-1] is 'Origin':
+                print('origin)
+        
+    
     # Remove confusing pixelOrigin. Use coords instead
     del im1['pixelOrigin']
 

--- a/ncempy/test/test_algo_multicorr.py
+++ b/ncempy/test/test_algo_multicorr.py
@@ -13,7 +13,7 @@ def test_multicorr():
     """
     Test to check if the correlation is working.
     """
-    g2 = np.zeros((3, 3), dtype=np.float)
+    g2 = np.zeros((3, 3), dtype=np.float32)
     test = neval.multicorr(np.fft.fft2(g2), np.fft.fft2(g2), 'phase', 3)
     assert list(test) == [0, 0]
 

--- a/ncempy/test/test_io_dm.py
+++ b/ncempy/test/test_io_dm.py
@@ -184,4 +184,4 @@ class Testdm3:
         file_name = data_location / Path('08_carbon.dm3')
         with ncempy.io.dm.fileDM(file_name) as dm0:
             _ = dm0.getMetadata(0)
-            print(_)
+            print(_['Calibrations Brightness Scale'])

--- a/ncempy/test/test_io_dm.py
+++ b/ncempy/test/test_io_dm.py
@@ -185,3 +185,4 @@ class Testdm3:
         with ncempy.io.dm.fileDM(file_name) as dm0:
             _ = dm0.getMetadata(0)
             print(_['Calibrations Brightness Scale'])
+

--- a/ncempy/test/test_io_dm.py
+++ b/ncempy/test/test_io_dm.py
@@ -179,3 +179,9 @@ class Testdm3:
         fid = open(file_name, 'rb')
         dm0 = ncempy.io.dm.fileDM(fid)
         assert hasattr(dm0, 'fid')
+
+    def test_metadata(self, data_location):
+        file_name = data_location / Path('08_carbon.dm3')
+        with ncempy.io.dm.fileDM(file_name) as dm0:
+            _ = dm0.getMetadata(0)
+            print(_)


### PR DESCRIPTION
Add a `getMetadata` function which parses the allTags attribute and keeps the most useful information. For example, the conversion of detector counts to electrons in a DM file (called the brightness or Intensity in Digital Micrograph) can now be more easily retrieved.