### PR TITLE
Fix stem minimal script

### DIFF
--- a/python_titan/STEM_minimal.py
+++ b/python_titan/STEM_minimal.py
@@ -1,19 +1,22 @@
 # A minimal script to test connecting to the microsocpe and TIA in STEM mode.
 # An image is acquired, but not saved.
 
-# Connect to FEI TEMScripting and TIA using COM
+# Connect to FEI TEMScripting and TIA using COM 
 from comtypes.client import CreateObject
 from comtypes.safearray import safearray_as_ndarray # get data across COM barrier fast
 
 def getPixelSize():
-    # Get the pixel calibration from TIA
+    """Get the pixel calibration from TIA
+    """
     window1 = TIA.ActiveDisplayWindow()
-    Im1 = window1.FindDisplay(window1.DisplayNames[0]) #returns an image display object
-    unit1 = Im1.SpatialUnit #returns SpatialUnit object
-    unitName = unit1.unitstring #returns a string (such as nm)
-    calX = Im1.image.calibration.deltaX #returns the x calibration in meters
+    Im1 = window1.FindDisplay(window1.DisplayNames[0]) # returns an image display object
+    unit1 = Im1.SpatialUnit # returns SpatialUnit object
+    unitName = unit1.unitstring # returns a string (such as nm)
+    calX = Im1.image.calibration.deltaX # returns the x calibration in meters
     calY = Im1.image.calibration.deltaY
-    print('pixel size = {:03}, {:03}'.format(calX,calY))
+    print('pixel size = {:03}, {:03}'.format(calX, calY))
+    return((calX, calY))
+
 _microscope = CreateObject('TEMScripting.Instrument')
 print("Connected to microscope")
 TIA = CreateObject('ESVision.Application')
@@ -23,9 +26,9 @@ print('Connected to TIA')
 Acq = _microscope.Acquisition
 Proj = _microscope.Projection
 Ill = _microscope.Illumination
-Stage = _microscope.Stage #FEI stage. Not needed for TEAM Stage
+Stage = _microscope.Stage 
 
-detector0 = Acq.Detectors(0) #older pythoncom versions might require square brackets []
+detector0 = Acq.Detectors(0) #old microscopes might require square brackets [] instead of ()
 # Add the detector
 Acq.AddAcqDevice(detector0)
 
@@ -34,15 +37,16 @@ myStemAcqParams.Binning = 8
 myStemAcqParams.ImageSize = 0 #_microscope.ACQIMAGESIZE_FULL
 myStemAcqParams.DwellTime = 1e-6
 Acq.Detectors.AcqParams = myStemAcqParams
-#Acq.RemoveAllAcqDevices()
 
 print(detector0.Info.Name)
 
-print('Acquire')
+print('Acquire image')
 acquiredImageSet = Acq.AcquireImages() 
 
+# This quickly retrieves the data across the COM barrier
+# and returns the data as a numpy ndarray
 with safearray_as_ndarray:
-    startIm = acquiredImageSet(0).AsSafeArray
+    image = acquiredImageSet(0).AsSafeArray
 
 getPixelSize()
 

--- a/python_titan/STEM_minimal.py
+++ b/python_titan/STEM_minimal.py
@@ -1,18 +1,7 @@
 # A minimal script to test connecting to the microsocpe and TIA in STEM mode.
 # An image is acquired, but not saved.
 
-import uuid
-import argparse
-version = 1.1 #version number for this program
-
-import numpy as np
-import socket
-import os
-import wx # wxPython GUI package
-import h5py
-import time
-
-# For connections to FEI TEMScripting and TIA
+# Connect to FEI TEMScripting and TIA using COM
 from comtypes.client import CreateObject
 from comtypes.safearray import safearray_as_ndarray # get data across COM barrier fast
 


### PR DESCRIPTION
The STEM minimal script had lots of imports that were not necessary. This is the minimal script needed to acquire a STEM image using TIA and get the pixel size from TIA.