### PR TITLE
Improve smv

### DIFF
--- a/ncempy/io/smv.py
+++ b/ncempy/io/smv.py
@@ -135,7 +135,7 @@ class fileSMV:
         """Read the header information and conver to numbers or strings."""
         
         self.fid.seek(0, 0)
-        head = self.fid.read(self.num_header_bytes).decode('UTF-8').split('\n')
+        head = self.fid.read(self.num_header_bytes).decode('UTF-8').splitlines()
         for line in head:
             if '=' in line:
                 key, val = line.split('=')

--- a/ncempy/io/smv.py
+++ b/ncempy/io/smv.py
@@ -123,10 +123,11 @@ class fileSMV:
         return None
     
     def _validate(self):
-        first_line = self.fid.read(15).decode('UTF-8')
-        if first_line == '{\nHEADER_BYTES=':
-            bytes_str = self.fid.readline().decode('UTF-8')
-            self.num_header_bytes = int(bytes_str.strip().strip(';'))
+        # first_line = self.fid.read(15).decode('UTF-8')
+        first_line = self.fid.readline() # should be {
+        second_line = self.fid.readline().decode('UTF-8') # should contain HEADER_BYTES
+        if 'HEADER_BYTES=' in second_line:
+            self.num_header_bytes = int(second_line.split('=')[1].strip().strip(';'))
             return True
         else:
             return False

--- a/ncempy/test/test_io_smv.py
+++ b/ncempy/test/test_io_smv.py
@@ -32,7 +32,6 @@ class Testsmv:
 
     def test_write_read(self, temp_file):
         # Write out a temporary SMV file
-        print(np.ones((10, 11), dtype=np.uint16).dtype)
         ncempy.io.smv.smvWriter(temp_file,
                                 np.ones((10, 11), dtype=np.uint16))
 


### PR DESCRIPTION
Improves reading of the header by using readline() instead of reading a set number of bytes. This should allow linux and windows line endings to be accommodated.