### PR TITLE
Improve emd warning

### DIFF
--- a/ncempy/io/__init__.py
+++ b/ncempy/io/__init__.py
@@ -41,13 +41,9 @@ def read(filename, dsetNum=0):
     elif suffix in ('.dm3', '.dm4'):
         out = dm.dmReader(filename)
     elif suffix in ('.emd', '.h5', '.hdf5'):
-        is_velox = False
-        with emd.fileEMD(filename) as emd0:
-            if len(emd0.list_emds) > 0:
-                out = emd.emdReader(filename, dsetNum)
-            else:
-                is_velox = True
-        if is_velox:
+        try:
+            out = emd.emdReader(filename, dsetNum)
+        except emd.NoEmdDataSets:
             out = emdVelox.emdVeloxReader(filename, dsetNum)
     elif suffix in ('.mrc', '.rec', '.st', '.ali'):
         out = mrc.mrcReader(filename)

--- a/ncempy/test/test_io_mrc.py
+++ b/ncempy/test/test_io_mrc.py
@@ -37,5 +37,5 @@ class Testmrc:
 
         assert temp_file.exists() is True
         with open(temp_file, 'rb') as f0:
-            mrc0 = ncempy.io.mrc.fileMRC(fid)
+            mrc0 = ncempy.io.mrc.fileMRC(f0)
             assert hasattr(mrc0, 'fid')


### PR DESCRIPTION
This makes the version warning more flexible. Previously if the version was not exactly 0.2 then a "Warning..." was printed which can be annoying. I removed this printing line and added an exception with some extra logic described below.

This PR adds two new custom exceptions to `emd`. One where no Berkeley EMD data sets are found and one for version mismatch.

A warning about version mismatch is only raised if:
- The version is not 0.2
AND
- no Berkely EMD data sets are found.

The exception is also used in `ncempy.read()` to differentiate Berkeley EMD and Velox EMD files.

A minor typo in the MRC test was also fixed.