### PR TITLE
String compatibility

### DIFF
--- a/ncempy/eval/ring_diff.py
+++ b/ncempy/eval/ring_diff.py
@@ -81,7 +81,7 @@ def get_settings( parent ):
     except:
         raise TypeError('Something wrong with the input.')
 
-    if not parent.attrs['type'] == np.string_(cur_set_vers):
+    if not parent.attrs['type'] == cur_set_vers:
         print('Don\'t  know the format of these settings.')
         return None
     
@@ -102,11 +102,11 @@ def get_settings( parent ):
         in_funcs = parent.attrs['fit_funcs'][0]
     else:
         in_funcs = parent.attrs['fit_funcs']
-    in_funcs = in_funcs.split(b',')
+    in_funcs = in_funcs.split(',')
         
     out_funcs = []
     for i in range(len(in_funcs)):
-        out_funcs.append(in_funcs[i].decode('utf-8').strip())
+        out_funcs.append(in_funcs[i].strip())
     settings['fit_funcs'] = tuple(out_funcs)
 
     if 'plt_imgminmax' in parent.attrs:
@@ -175,7 +175,7 @@ def put_settings( parent, settings ):
         
         
     # set version information    
-    grp_set.attrs['type'] = np.string_(cur_set_vers)
+    grp_set.attrs['type'] = cur_set_vers
     
     # hardcoding the written settings to keep control
     grp_set.attrs['lmax_r'] = settings['lmax_r']
@@ -192,7 +192,7 @@ def put_settings( parent, settings ):
     fit_funcs = []
     for i in range(len(settings['fit_funcs'])):
         fit_funcs.append(settings['fit_funcs'][i])
-    grp_set.attrs['fit_funcs'] = np.string_(', '.join(fit_funcs))
+    grp_set.attrs['fit_funcs'] = ', '.join(fit_funcs)
     
     if not settings['plt_imgminmax'] is None:
         grp_set.attrs['plt_imgminmax'] = settings['plt_imgminmax']
@@ -240,11 +240,11 @@ def put_sglgroup(parent, label, data_grp):
 
     # create the evaluation group
     grp = parent.create_group(label)
-    grp.attrs['type'] = np.string_(cur_eva_vers)
+    grp.attrs['type'] = cur_eva_vers
     
     # put a link to the data
-    grp.attrs['filename'] = np.string_(data_grp.file.filename)
-    grp.attrs['internal_path'] = np.string_(data_grp.name)
+    grp.attrs['filename'] = data_grp.file.filename
+    grp.attrs['internal_path'] = data_grp.name
     #grp['emdgroup'] = h5py.ExternalLink(data_grp.file.filename, data_grp.name)    
     
     return grp
@@ -270,7 +270,7 @@ def run_sglgroup(group, outfile, overwrite=False, verbose=False, showplots=False
 
     try:
         assert(isinstance(group, h5py._hl.group.Group))
-        assert( group.attrs['type'] == np.string_(cur_eva_vers) )
+        assert( group.attrs['type'] == cur_eva_vers)
         
         assert(isinstance(outfile, ncempy.io.emd.fileEMD))
     except:
@@ -281,9 +281,9 @@ def run_sglgroup(group, outfile, overwrite=False, verbose=False, showplots=False
 
     # get the emdgroup
     if verbose:
-        print('.. getting data from {}:{}'.format(group.attrs['filename'].decode('utf-8'), group.attrs['internal_path'].decode('utf-8')))
-    readfile = ncempy.io.emd.fileEMD( group.attrs['filename'].decode('utf-8'), readonly=True )
-    data, dims = readfile.get_emdgroup(readfile.file_hdl[group.attrs['internal_path'].decode('utf-8')])
+        print('.. getting data from {}:{}'.format(group.attrs['filename'], group.attrs['internal_path']))
+    readfile = ncempy.io.emd.fileEMD( group.attrs['filename'], readonly=True )
+    data, dims = readfile.get_emdgroup(readfile.file_hdl[group.attrs['internal_path']])
     
     # find the settings moving upwards in hierarchy
     if verbose:
@@ -292,7 +292,7 @@ def run_sglgroup(group, outfile, overwrite=False, verbose=False, showplots=False
         #print('scanning group {}'.format(grp))
         if 'settings_ringdiffraction' in grp:
             stt = grp['settings_ringdiffraction']
-            if stt.attrs['type'] == np.string_(cur_set_vers):
+            if stt.attrs['type'] == cur_set_vers:
                 return stt
         else:
             if not grp == grp.file:
@@ -394,7 +394,7 @@ def run_all(parent, outfile, overwrite=False, verbose=False, showplots=False):
             if grp.get(item, getclass=True) == h5py._hl.group.Group:
                 item = grp.get(item)
                 if 'type' in item.attrs:
-                    if item.attrs['type'] == np.string_(cur_eva_vers):
+                    if item.attrs['type'] == cur_eva_vers:
                         todo.append(item)
                         if verbose:
                             print('Found evaluation group at "{}".'.format(item.name) )

--- a/ncempy/io/emd.py
+++ b/ncempy/io/emd.py
@@ -400,8 +400,8 @@ class fileEMD:
 
         try:
             dset = parent.create_dataset(label, data=dim[0])
-            dset.attrs['name'] = np.string_(dim[1])
-            dset.attrs['units'] = np.string_(dim[2])
+            dset.attrs['name'] = dim[1]
+            dset.attrs['units'] = dim[2]
         except:
             raise RuntimeError('Error during writing dim dataset')
 
@@ -522,11 +522,11 @@ class fileEMD:
         # write comment
         if timestamp in self.comments.attrs:
             # append to existing
-            self.comments.attrs[timestamp] += np.string_('\n' + msg)
+            self.comments.attrs[timestamp] += '\n' + msg
 
         else:
             # create new entry
-            self.comments.attrs[timestamp] = np.string_(msg)
+            self.comments.attrs[timestamp] = msg
         
 
 def defaultDims(data, pixel_size=None, pixel_unit=None):

--- a/ncempy/io/ser.py
+++ b/ncempy/io/ser.py
@@ -1016,7 +1016,7 @@ def read_emi(filename):
 
 
 def _parseEntry_emi(value):
-    """Auxiliary function to parse string entry to int, float or np.string_().
+    """Auxiliary function to parse string entry to int, float or str.
 
     Parameters
     ----------
@@ -1039,7 +1039,7 @@ def _parseEntry_emi(value):
             p = float(value)
         except ValueError:
             # if neither int nor float, stay with string
-            p = np.string_(str(value))
+            p = str(value)
 
     return p
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.11.1',
+    version='1.12',
 
     description='openNCEM\'s Python Package',
     long_description=long_description,
@@ -55,9 +55,9 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
     # What does your project relate to?
@@ -75,7 +75,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy', 'scipy', 'matplotlib', 'h5py>=2.9.0'],
+    install_requires=['numpy>=2', 'scipy', 'matplotlib', 'h5py>=3'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This removes the deprecated `np.string_` function. H5py used to suggest using this for storing strings, but that is no longer true for > h5py version 3. We now just use `str`.