### PR TITLE
[feat] use keys_to_ignore in fileEMDVelox getMetadata

### DIFF
--- a/ncempy/io/emdVelox.py
+++ b/ncempy/io/emdVelox.py
@@ -274,12 +274,15 @@ class fileEMDVelox:
             metadata is loaded and parsed by the json module into a dictionary.
         """
         self._parseMetadata(group)
-        useful_keys = ('Optics', 'Stage', 'Scan', 'BinaryResult' )
+        keys_to_ignore = ('EnergyFilter', 'Vacuum', 'GasInjectionSystems', 'CustomProperties') 
+        # note: CustomProperties handled separately below
+        
         meta_data = {}
         for kk in self.metaDataJSON.keys():
-            if kk in useful_keys:
+            if kk not in keys_to_ignore:
                meta_data.update(self.metaDataJSON[kk])
         
+        # separate handling of CustomProperties 
         for kk, vv in self.metaDataJSON['CustomProperties'].items():
             try:
                 if isinstance(vv, dict):


### PR DESCRIPTION
updates to the `fileEMDVelox` class:

* in `getMetadata`: include everything in `metaDataJSON` except for `keys_to_ignore` ('EnergyFilter', 'Vacuum', 'GasInjectionSystems')
     * whereas, previously only `useful_keys` ('Optics', 'Stage', 'Scan', 'BinaryResult' ) were kept.

Testing: 
* `test_io_emdVelox.py` is passing, but when I tried to run all the tests, `test_eels.py` is failing. However, the eels test doesn't seem relevant to my changes.
```ncempy/test/test_eels.py:11: in <module>
    import ncempy.algo.eels as eels
E   ModuleNotFoundError: No module named 'ncempy.algo.eels'
```