### PR TITLE
Add python_titan and tools doc pages, fix example wording

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,10 +27,8 @@ The openNCEM collection comes with different components. The general functionali
    :maxdepth: 2
 
     ncempy - openNCEM's python package<ncempy>
-    tools - wrapping the provided functionality into useful tools<tools>
-
-**python_titan**
-    A set of open source automation packages for Thermo Fisher transmission electron microscopes.
+    tools - wraps the provided functionality in ncempy into useful tools<tools>
+    python_titan - a set of open source automation packages for Thermo Fisher transmission electron microscopes<python_titan>
 
 Examples
 --------
@@ -43,22 +41,22 @@ an easily human readable form.
 
 .. code-block:: python
    
-   >>> import ncempy.io as nio
-   >>> dmData = nio.read('path/to/file/data.dm3')
-   >>> print(dmData['data'].shape) # the shape of the data
-   >>> print(dmData['pixelSize']) # print the pixel size
+   >>> import ncempy
+   >>> data = ncempy.read('path/to/file/data.dm3')
+   >>> print(data['data'].shape) # the shape of the data
+   >>> print(data['pixelSize']) # print the pixel size
 
 For developers
 ^^^^^^^^^^^^^^
-Developers will want access to the entire internal structure of the file.
-Then you need to instantiate the class, parse the header and then access its contents
+Developers may want access to the entire internal structure of the file.
+Instantiate the class, parse the header, and access the full contents.
 
 Here is how to open a DM file and have access to the internal file parameters
 
 .. code-block:: python
 
-   >>> import ncempy.io as nio
-   >>> with nio.dm.fileDM('/path/to/file/data.dm3') as dm0:
+   >>> import ncempy
+   >>> with ncempy.io.dm.fileDM('/path/to/file/data.dm3') as dm0:
    >>>     dmData = dm0.getDataset(0) #the full first data set
    >>>     dmSlice = dm0.getSlice(0, 1) #the second image of the first data set; equal to dmData[1,:,:] from the line above
    >>>     print(dm0.metaData) # all of the interesting metadata for this data set (pixel size, accelerating voltage, etc.)
@@ -72,8 +70,8 @@ full 4D data set from the master file.
 
 .. code-block:: python
 
-   >>> import ncempy.io as nio
-   >>> with nio.dectris.fileDECTRIS('/path/to/file/master.h5') as f0:
+   >>> import ncempy
+   >>> with ncempy.io.dectris.fileDECTRIS('/path/to/file/master.h5') as f0:
    >>>     data = f0.getDataset() # the full 4D data set, shape [scanY, scanX, frameY, frameX]
    >>>     print(data['data'].shape)
    >>>     print(f0.getMetadata()) # scan metadata (e.g. pixel size), if available

--- a/docs/python_titan.rst
+++ b/docs/python_titan.rst
@@ -1,0 +1,26 @@
+python_titan
+============
+
+A set of open source automation packages for Thermo Fisher (FEI) transmission electron microscopes. These scripts connect directly to the microscope and TIA using COM (via the ``comtypes`` package) to control acquisition and stage movements, and are not part of the installable ``ncempy`` package.
+
+They currently support the NCEM TEAM Stage and the FEI Compustage.
+
+STEM_minimal.py
+----------------
+
+A minimal script demonstrating how to connect to the microscope and TIA in STEM mode and acquire a single image (not saved).
+
+STEMexperiments.py
+-------------------
+
+Acquires STEM data experiments such as focal series, scanning rotation series, time series, and single images. All data is saved as a Berkeley EMD file, readable with ``ncempy.io.emd``.
+
+STEMTomo7.py
+-------------
+
+Acquires STEM tomography tilt series manually, saving all metadata and images to a Berkeley EMD file. Supports multiple images per tilt angle or a scan rotation series for dose fractionation and drift correction. Works with both the TEAM Stage and the FEI Compustage.
+
+KStilter.py
+------------
+
+Determines the tilt required to bring a crystal on axis by clicking a position in a CBED pattern. Currently only works with the NCEM TEAM Stage and the FEI Flucam.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -1,0 +1,28 @@
+tools
+=====
+
+The collection of tools provided with openNCEM. These are based on the algorithms and routines contained in ``ncempy`` and are meant to provide solutions to specific problems. They are subordered by the experiment/simulation/task they address.
+
+The GUI tools come with additional requirements:
+
+* PySide (for GUI)
+* pyqtgraph (for plotting in GUI)
+
+RingDiff
+--------
+
+Tool to evaluate ring diffraction patterns. The command line tool is split into two parts: ``cmdline_ringdiff_prepare`` creates an evaluation file, and ``cmdline_ringdiff_run`` executes the evaluation. This allows settings to be modified with an external HDF5 tool (such as the HDF Viewer) before running the evaluation.
+
+The GUI tool allows a standalone evaluation of ring diffraction patterns. It can read EMD files containing a single or a series of diffraction patterns, or read the settings and linked data from an evaluation file.
+
+ser2emd
+-------
+
+A converter to read SER files and save them as EMD files. Optionally an EMI file is parsed as well to retrieve the metadata.
+
+A command line as well as a GUI version are available. Run ``python3 gui_ser2emd.py`` for the GUI, or ``python3 cmdline_ser2emd.py --help`` for command line usage.
+
+tif2emd
+-------
+
+GUI tools to convert TIF files to EMD files, for either a single TIF file or a series of TIF files.


### PR DESCRIPTION
Follow-up to the docs modernization merged in #87, which only included the first commit of the update-docs branch. This carries over the rest:

- Link python_titan properly in the Components toctree instead of as plain bold text (it needs a real docs/python_titan.rst target).
- Add docs/tools.rst and docs/python_titan.rst: docs/tools.rst had been deleted in a much older commit but the toctree entry pointing to it was never removed, so it silently failed to render on RTD.
- Reword the ncempy.read()/fileDM examples in docs/index.rst to use `import ncempy` directly instead of `import ncempy.io as nio`.